### PR TITLE
Use a unique coverage variable like istanbul command does

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 "use strict";
+var COVERAGE_VARIABLE = '$$cov_' + new Date().getTime() + '$$';
+
 var through = require('through2').obj;
 var path = require("path");
 var istanbul = require("istanbul");
 var hook = istanbul.hook;
 var Report = istanbul.Report;
 var Collector = istanbul.Collector;
-var instrumenter = new istanbul.Instrumenter();
+var instrumenter = new istanbul.Instrumenter({ coverageVariable:COVERAGE_VARIABLE });
 
 
 var plugin  = module.exports = function () {
@@ -41,7 +43,7 @@ plugin.writeReports = function (dir) {
 
     var collector = new Collector();
 
-    collector.add(global.__coverage__);
+    collector.add(global[COVERAGE_VARIABLE]);
 
 
     var reports = [
@@ -51,6 +53,8 @@ plugin.writeReports = function (dir) {
         Report.create("text-summary")
     ];
     reports.forEach(function (report) { report.writeReport(collector, true); });
+
+    delete global[COVERAGE_VARIABLE];
 
   }).resume();
 

--- a/test/main.js
+++ b/test/main.js
@@ -1,4 +1,4 @@
-/*global describe, it*/
+/*global describe, it, beforeEach, after */
 'use strict';
 
 var fs = require('fs');
@@ -29,7 +29,7 @@ describe('gulp-istanbul', function () {
       this.stream.on('data', function (file) {
         assert.equal(file.path, libFile.path);
         assert.ok(file.contents.toString().indexOf('__cov_') >= 0);
-        assert.ok(file.contents.toString().indexOf('__coverage__') >= 0);
+        assert.ok(file.contents.toString().indexOf('$$cov_') >= 0);
         done();
       });
 


### PR DESCRIPTION
sandboxed-module looks for a specific global var that starts with '$$cov_'.  This patch uses that convention so sandboxed-module tests are also included in code coverage.  See https://github.com/felixge/node-sandboxed-module/blob/master/lib/sandboxed_module.js#L240 and https://github.com/gotwarlost/istanbul/blob/master/lib/command/common/run-with-cover.js#L147

Also a bit of tidying in package.json and jshintrc
