### PR TITLE
Pass all options through to Istanbul Instrumenter constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Instrument files passed in the stream.
 Type: `Object` (optional)
 ```js
 {
-  coverageVariable: 'someVariable'
+  coverageVariable: 'someVariable',
+  ...other Instrumeter options...
 }
 ```
 
@@ -57,6 +58,12 @@ The global variable istanbul uses to store coverage
 See also:
 - [istanbul coverageVariable][istanbul-coverage-variable]
 - [SanboxedModule][sandboxed-module-coverage-variable]
+
+##### Other Istanbul Instrutrumenter options
+
+See:
+- [istanbul Instrumenter documentation][istanbul-coverage-variable]
+
 
 ### istanbul.summarizeCoverage(opt)
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var plugin  = module.exports = function (opts) {
     return fileMap[path];
   });
 
-  var instrumenter = new istanbul.Instrumenter({ coverageVariable: opts.coverageVariable });
+  var instrumenter = new istanbul.Instrumenter(opts);
 
   return through(function (file, enc, cb) {
     if (!file.contents instanceof Buffer) {


### PR DESCRIPTION
This allows options other than coverageVariable to be used without
specifying them all in this module.
