### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ plugin.writeReports = function (opts) {
 
   cover.on('end', function () {
     var collector = new Collector();
-    collector.add(global[opts.coverageVariable]);
+    collector.add(global[opts.coverageVariable] || {}); //revert to an object if there are not macthing source files.
     reporters.forEach(function (report) { report.writeReport(collector, true); });
     delete global[opts.coverageVariable];
   }).resume();


### PR DESCRIPTION
If there are no matching source files for a test then collector.add(...) tries to add an undefined object. since the collector just loops through the keys it should just skip over the supplied empty object from the  || {}.

https://github.com/SBoudrias/gulp-istanbul/issues/27
