### PR TITLE
Fix check for Buffer in through2 callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var plugin  = module.exports = function (opts) {
   var instrumenter = new istanbul.Instrumenter(opts);
 
   return through(function (file, enc, cb) {
-    if (!file.contents instanceof Buffer) {
+    if (!(file.contents instanceof Buffer)) {
       return cb(new PluginError(PLUGIN_NAME, 'streams not supported'), undefined);
     }
 


### PR DESCRIPTION
There are incorrect checking for "not a Buffer" where statement's body is unreachable

``` js
if (!42 instance of Buffer) {
   // this block never executed
   throw 'smth';
}
```

correct is

``` js
if (!(file.contents instance of Buffer)) {
   // error
}
```
