### PR TITLE
Pull all files with resume.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var plugin = module.exports = function (opts) {
 
   var instrumenter = new istanbul.Instrumenter(opts);
 
-  return through(function (file, enc, cb) {
+  var stream = through(function (file, enc, cb) {
     cb = _.once(cb);
     if (!(file.contents instanceof Buffer)) {
       return cb(new PluginError(PLUGIN_NAME, 'streams not supported'));
@@ -66,6 +66,10 @@ var plugin = module.exports = function (opts) {
       return cb(err, file);
     });
   });
+
+  stream.resume();
+
+  return stream;
 };
 
 plugin.summarizeCoverage = function (opts) {


### PR DESCRIPTION
We need to use .resume to ensure we pull all files from stream and not only the first 16 files.

This is experienced when using file blobs which includes wildcards and finds more than 16 files.
