### PR TITLE
Add option for custom instrumentor

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ Flag to include test coverage of files that aren't `require`d by any tests
 See also:
 - [istanbul "0% coverage" issue](https://github.com/gotwarlost/istanbul/issues/112)
 
+##### instrumentor
+Type: `Instrumentor` (optional)
+Default: `istanbul.Instrumentor`
+
+Custom Instrumentor to be used instead of the default istanbul one.
+
+See also:
+- [isparta](https://github.com/douglasduteil/isparta)
+
 ##### Other Istanbul Instrumenter options
 
 See:

--- a/index.js
+++ b/index.js
@@ -16,8 +16,9 @@ var plugin = module.exports = function (opts) {
   opts = opts || {};
   opts.includeUntested = opts.includeUntested === true;
   if (!opts.coverageVariable) opts.coverageVariable = COVERAGE_VARIABLE;
+  if (!opts.instrumenter) opts.instrumenter = istanbul.Instrumenter;
 
-  var instrumenter = new istanbul.Instrumenter(opts);
+  var instrumenter = new opts.instrumenter(opts);
 
   return through(function (file, enc, cb) {
     cb = _.once(cb);

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     "through2": "^0.6.3"
   },
   "devDependencies": {
+    "6to5": "^1.15.0",
     "gulp": "^3.6.2",
     "gulp-mocha": "^2.0.0",
+    "isparta": "^0.1.2",
     "jshint": "^2.5.0",
     "mocha": "^2.0.1",
     "rimraf": "^2.2.8"

--- a/test/main.js
+++ b/test/main.js
@@ -6,6 +6,7 @@ var rimraf = require('rimraf');
 var gutil = require('gulp-util');
 var gulp = require('gulp');
 var istanbul = require('../');
+var isparta = require('isparta');
 var mocha = require('gulp-mocha');
 
 var out = process.stdout.write.bind(process.stdout);
@@ -70,6 +71,26 @@ describe('gulp-istanbul', function () {
         done();
       });
       this.stream.write(srcFile);
+      this.stream.end();
+    });
+  });
+
+  describe('istanbul() with custom instrumentor', function() {
+    beforeEach(function () {
+      this.stream = istanbul({
+        instrumentor: isparta.Instrumentor
+      });
+    });
+
+    it('instrument files', function (done) {
+      this.stream.on('data', function (file) {
+        assert.equal(file.path, libFile.path);
+        assert(file.contents.toString().indexOf('__cov_') >= 0);
+        assert(file.contents.toString().indexOf('$$cov_') >= 0);
+        done();
+      });
+
+      this.stream.write(libFile);
       this.stream.end();
     });
   });


### PR DESCRIPTION
Using `isparta` instead of `instanbul` you can get ES6/ES7/JSX/Flow support via 6to5. 

This adds an option to customize the instrumentor.