### PR TITLE
Removed on end as this causes gulp to error with an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ gulp.task('test', function (cb) {
     .on('finish', function () {
       gulp.src(['test/*.js'])
         .pipe(mocha())
-        .pipe(istanbul.writeReports()) // Creating the reports after tests runned
-        .on('end', cb);
+        .pipe(istanbul.writeReports()); // Creating the reports after tests runned
     });
 });
 ```


### PR DESCRIPTION
extra on('end') causes "Error: task completion callback called too many times" at end of test run.