### PR TITLE
add covStub to file object when includeUntested is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ var plugin = module.exports = function (opts) {
           var covStub = JSON.parse(covStubMatch[0]);
           global[opts.coverageVariable] = global[opts.coverageVariable] || {};
           global[opts.coverageVariable][path.resolve(file.path)] = covStub;
+          file.covStub = covStub;
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "6to5": "^3.2.1",
+    "event-stream": "^3.2.2",
     "gulp": "^3.6.2",
     "gulp-mocha": "^2.0.0",
     "isparta": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "6to5": "^3.2.1",
-    "event-stream": "^3.2.2",
     "gulp": "^3.6.2",
     "gulp-mocha": "^2.0.0",
     "isparta": "^1.0.1",

--- a/test/main.js
+++ b/test/main.js
@@ -8,7 +8,7 @@ var gulp = require('gulp');
 var istanbul = require('../');
 var isparta = require('isparta');
 var mocha = require('gulp-mocha');
-var es = require('event-stream');
+var through = require('through2').obj;
 
 var out = process.stdout.write.bind(process.stdout);
 
@@ -83,11 +83,11 @@ describe('gulp-istanbul', function () {
             coverageVariable: COV_VAR,
             includeUntested: true
         }))
-        .pipe(es.through(function (file) {
+        .pipe(through(function (file, enc, callback) {
           covStubs[file.path] = file.covStub;
           this.push(file);
-        }))
-        .on('end', function () {
+          callback();
+        }, function (callback) {
           var filePaths = Object.keys(covStubs);
           assert(filePaths.length === 2, '2 files with covStub');
           filePaths.forEach(function (filePath) {
@@ -99,8 +99,9 @@ describe('gulp-istanbul', function () {
             assert(covStubs[filePath].hasOwnProperty('statementMap'), 'covStub has statementMap');
             assert(covStubs[filePath].hasOwnProperty('branchMap'), 'covStub has branchMap');
           });
+          callback();
           done();
-        });
+        }));
     });
 
   });


### PR DESCRIPTION
This allows downstream consumers to produces a report with includes uncovered files.