### PR TITLE
Added support for custom reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Type: `Object` (optional)
 ```js
 {
   dir: './coverage',
-  reporters: [ 'lcov', 'json', 'text', 'text-summary' ],
+  reporters: [ 'lcov', 'json', 'text', 'text-summary', CustomReport ],
   reportOpts: { dir: './coverage' },
   coverageVariable: 'someVariable'
 }
@@ -197,6 +197,8 @@ The list of available reporters:
 - `teamcity`
 - `text`
 - `text-summary`
+
+You can also specify one or more custom reporter objects as items in the array. These will be automatically registered with istanbul.
 
 See also `require('istanbul').Report.getReportList()`
 

--- a/index.js
+++ b/index.js
@@ -99,13 +99,18 @@ plugin.writeReports = function (opts) {
     reportOpts: { dir: opts.dir || defaultDir }
   });
 
-  var invalid = _.difference(opts.reporters, Report.getReportList());
+  var reporters = opts.reporters.map(function(reporter) {
+    if (reporter.TYPE) Report.register(reporter);
+    return reporter.TYPE || reporter;
+  });
+
+  var invalid = _.difference(reporters, Report.getReportList());
   if (invalid.length) {
     // throw before we start -- fail fast
     throw new PluginError(PLUGIN_NAME, 'Invalid reporters: ' + invalid.join(', '));
   }
 
-  var reporters = opts.reporters.map(function (r) {
+  reporters = reporters.map(function (r) {
     return Report.create(r, _.clone(opts.reportOpts));
   });
 


### PR DESCRIPTION
There's currently no way to use custom reporters through gulp-istanbul. The instance of istanbul inside the gulp plugin seems to be different from the one outside the plugin, so it's not possible to register custom reporters in gulp tasks.

I added the functionality to do this, and updated tests and docs.