### PR TITLE
gulp-istanbul no longer works with istanbul 0.3.13

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ var plugin = module.exports = function (opts) {
 plugin.hookRequire = function (options) {
   var fileMap = {};
 
+  istanbul.hook.unhookRequire();
   istanbul.hook.hookRequire(function (path) {
     return !!fileMap[path];
   }, function (code, path) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-istanbul",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Istanbul unit test coverage plugin for gulp.",
   "keywords": [
     "gulpplugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-istanbul",
-  "version": "0.7.1",
+  "version": "0.7.0",
   "description": "Istanbul unit test coverage plugin for gulp.",
   "keywords": [
     "gulpplugin",


### PR DESCRIPTION
Tests are broken because `hookRequire()` can't be called twice.
Resolve #54 