### PR TITLE
Adds support for individual configuration per reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,18 @@ Type: `Object` (optional)
 }
 ```
 
+You can pass individual configuration to a reporter.
+```js
+{
+  dir: './coverage',
+  reporters: [ 'lcovonly', 'json', 'text', 'text-summary', CustomReport ],
+  reportOpts: { 
+    lcov: {dir: 'lcovonly', file: 'lcov.info'}
+    json: {dir: 'json', file: 'converage.json'}
+  },
+  coverageVariable: 'someVariable'
+}
+```
 ##### dir
 Type: `String` (optional)
 Default: `./coverage`

--- a/index.js
+++ b/index.js
@@ -113,7 +113,8 @@ plugin.writeReports = function (opts) {
   }
 
   reporters = reporters.map(function (r) {
-    return Report.create(r, _.clone(opts.reportOpts));
+    var reportOpts = opts.reportOpts[r] || opts.reportOpts;
+    return Report.create(r, _.clone(reportOpts));
   });
 
   var cover = through();

--- a/test/main.js
+++ b/test/main.js
@@ -248,6 +248,30 @@ describe('gulp-istanbul', function () {
         });
     });
 
+    it('allow specifying configuration per report', function (done) {
+      process.stdout.write = function () {};
+      var opts = {
+        reporters: ['lcovonly', 'json'],
+        reportOpts: {
+          lcovonly: { dir: 'lcovonly', file: 'lcov-test.info' },
+          json: { dir: 'json', file: 'json-test.info' }
+        }
+      };
+
+      gulp.src(['test/fixtures/test/*.js'])
+        .pipe(mocha())
+        .pipe(istanbul.writeReports(opts))
+        .on('end', function() {
+          process.stdout.write = out;
+          assert(fs.existsSync('./lcovonly'));
+          assert(fs.existsSync('./lcovonly/lcov-test.info'));
+          assert(fs.existsSync('./json'));
+          assert(fs.existsSync('./json/json-test.info'));
+          process.stdout.write = out;
+          done();
+        });
+    });
+
     it('allows specifying custom reporters', function (done) {
       var ExampleReport = function() {};
       ExampleReport.TYPE = 'example';


### PR DESCRIPTION
Sometime we want to pass more configuration to a reporter than only the dir name.
This PR adds support to define individual configuration to a specific reporter inside the reportOpts.
