### PR TITLE
Include hookRunInThisContext configuration

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -18,5 +18,17 @@
     "strict": true,
     "trailing": true,
     "smarttabs": true,
-    "white": true
+    "white": true,
+
+    "overrides": {
+      "test/**/global*.js": {
+        "strict": false,
+        "unused": false
+      }
+    },
+
+    "globals": {
+        "addFunc": true,
+        "missedFunc": true
+    }
 }

--- a/index.js
+++ b/index.js
@@ -78,6 +78,25 @@ plugin.hookRequire = function (options) {
   });
 };
 
+plugin.hookRunInThisContext = function (options) {
+  var fileMap = {};
+
+  istanbul.hook.unhookRunInThisContext();
+  istanbul.hook.hookRunInThisContext(function (path) {
+    return !!fileMap[path];
+  }, function (code, path) {
+    return fileMap[path];
+  }, options);
+
+  return through(function (file, enc, cb) {
+    // If the file is already required, delete it from the cache otherwise the covered
+    // version will be ignored.
+    delete require.cache[path.resolve(file.path)];
+    fileMap[file.path] = file.contents.toString();
+    return cb();
+  });
+};
+
 plugin.summarizeCoverage = function (opts) {
   opts = opts || {};
   if (!opts.coverageVariable) opts.coverageVariable = COVERAGE_VARIABLE;

--- a/test/fixtures/lib/add.js
+++ b/test/fixtures/lib/add.js
@@ -1,9 +1,9 @@
 'use strict';
 
-exports.add = function (a, b) {
+exports.add = function addFunc(a, b) {
   return a + b;
 };
 
-exports.missed = function () {
+exports.missed = function missedFunc() {
   return "not covered";
 };

--- a/test/fixtures/lib/global-vm-add.js
+++ b/test/fixtures/lib/global-vm-add.js
@@ -1,0 +1,7 @@
+function addFunc(a, b) {
+  return a + b;
+}
+
+function missedFunc() {
+  return "not covered";
+}

--- a/test/fixtures/test/vm-add.js
+++ b/test/fixtures/test/vm-add.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var fs = require('fs'),
+  vm = require('vm'),
+  vmInclude = function(code, path) {
+    vm.runInThisContext(code, path);
+  },
+  vmAddFile = function(path) {
+    vmInclude(fs.readFileSync(path), path);
+  };
+
+vmAddFile(__dirname+'/../lib/global-vm-add.js');

--- a/test/main.js
+++ b/test/main.js
@@ -111,24 +111,44 @@ describe('gulp-istanbul', function () {
     });
   });
 
+  describe('.hookRunInThisContext()', function () {
+    it('clear covered files from require.cache', function (done) {
+      var stream = istanbul()
+        .pipe(istanbul.hookRunInThisContext())
+        .on('finish', function () {
+          require('./fixtures/test/vm-add');
+          assert.notEqual(addFunc, null);
+          done();
+        });
+      stream.write(libFile);
+      stream.end();
+    });
+  });
+
   describe('istanbul.summarizeCoverage()', function () {
 
     it('gets statistics about the test run', function (done) {
-      gulp.src([ 'test/fixtures/lib/*.js' ])
+      gulp.src([ 'test/fixtures/lib/global-*.js' ])
         .pipe(istanbul())
-        .pipe(istanbul.hookRequire())
+        .pipe(istanbul.hookRunInThisContext())
         .on('finish', function () {
-          process.stdout.write = function () {};
-          gulp.src([ 'test/fixtures/test/*.js' ])
-            .pipe(mocha())
-            .on('end', function () {
-              var data = istanbul.summarizeCoverage();
-              process.stdout.write = out;
-              assert.equal(data.lines.pct, 75);
-              assert.equal(data.statements.pct, 75);
-              assert.equal(data.functions.pct, 50);
-              assert.equal(data.branches.pct, 100);
-              done();
+          gulp.src(['test/fixtures/lib/*.js', '!test/fixtures/lib/global-*.js'])
+            .pipe(istanbul())
+            .pipe(istanbul.hookRequire())
+            .on('finish', function () {
+              process.stdout.write = function () {
+              };
+              gulp.src(['test/fixtures/test/*.js'])
+                .pipe(mocha())
+                .on('end', function () {
+                  var data = istanbul.summarizeCoverage();
+                  process.stdout.write = out;
+                  assert.equal(data.lines.pct, 75);
+                  assert.equal(data.statements.pct, 75);
+                  assert.equal(data.functions.pct, 50);
+                  assert.equal(data.branches.pct, 100);
+                  done();
+                });
             });
         });
     });
@@ -136,7 +156,7 @@ describe('gulp-istanbul', function () {
     it('allows inclusion of untested files', function (done) {
       var COV_VAR = 'untestedCovVar';
 
-      gulp.src([ 'test/fixtures/lib/*.js' ])
+      gulp.src([ 'test/fixtures/lib/*.js', '!test/fixtures/lib/global-*.js' ])
         .pipe(istanbul({
             coverageVariable: COV_VAR,
             includeUntested: true
@@ -144,7 +164,7 @@ describe('gulp-istanbul', function () {
         .pipe(istanbul.hookRequire())
         .on('finish', function () {
           process.stdout.write = function () {};
-          gulp.src([ 'test/fixtures/test/*.js' ])
+          gulp.src([ 'test/fixtures/test/*.js', '!test/fixtures/lib/global-*.js' ])
             .pipe(mocha())
             .on('end', function () {
               var data = istanbul.summarizeCoverage({


### PR DESCRIPTION
#75 - works in my project [nsmockup](https://github.com/suiteplus/nsmockup)
```javascript
gulp.task('coverage', function () {
        return gulp.src(paths.js)
            .pipe(plugins.istanbul({
                includeUntested: true,
                instrumenter: require('isparta').Instrumenter
            })) // Covering files
            .pipe(plugins.istanbul.hookRunInThisContext()) // Force `vm.runInThisContext` to return covered files
            .on('finish', function () {
                let path = '/test/**/*'+ (file ? file + '*' : '') + '-test.js';
                gulp.src([appRoot + path])
                    .pipe(plugins.mocha({
                        reporters: 'spec'
                    }))
                    .pipe(plugins.istanbul.writeReports({
                        reports: ['lcovonly']
                    })); // Creating the reports after tests runned
            });
    });
```