### PR TITLE
Update istanbul dependency to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "gulp-util": "^3.0.1",
-    "istanbul": "^0.3.2",
+    "istanbul": "^0.4.0",
     "istanbul-threshold-checker": "^0.1.0",
     "lodash": "^3.0.1",
     "through2": "^2.0.0"


### PR DESCRIPTION
istanbul 0.4.0 has much nicer formatting of html reports. Works fine with the existing version of gulp-istanbul.