### PR TITLE
Put the require of the istanbul-threshold-checker before requiring istanbul.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,13 @@
 
 var through = require('through2').obj;
 var path = require('path');
+var checker = require('istanbul-threshold-checker');
 var istanbul = require('istanbul');
 var gutil = require('gulp-util');
 var _ = require('lodash');
 var Report = istanbul.Report;
 var Collector = istanbul.Collector;
 var PluginError = gutil.PluginError;
-var checker = require('istanbul-threshold-checker');
 
 var PLUGIN_NAME = 'gulp-istanbul';
 var COVERAGE_VARIABLE = '$$cov_' + new Date().getTime() + '$$';

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 var through = require('through2').obj;
 var path = require('path');
 var checker = require('istanbul-threshold-checker');
+// Make sure istanbul is `require`d after the istanbul-threshold-checker to use the istanbul version 
+// defined in this package.json instead of the one defined in istanbul-threshold-checker.
 var istanbul = require('istanbul');
 var gutil = require('gulp-util');
 var _ = require('lodash');


### PR DESCRIPTION
This way the last istanbul has preference over the istanbul required in the threshold checker, as this is an older version and was (partially) used when generating the reports.

This would show in having the coverage bars filling to 100px instead of 100% as it somehow used the html.js from the 0.3 version required in istanbul-threshold-checker instead of the 0.4 from gulp-istanbul. But with all the new css and stuff.

Environment: Windows 10, npm 3.3.0, node 5.1.0.