### PR TITLE
Provide an option to skip path resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ var plugin = module.exports = function (opts) {
     instrumenter: istanbul.Instrumenter
   });
   opts.includeUntested = opts.includeUntested === true;
-  opts.resolveAbsolutePaths = opts.resolveAbsolutePaths === true;
 
   var instrumenter = new opts.instrumenter(opts);
 
@@ -30,10 +29,6 @@ var plugin = module.exports = function (opts) {
     cb = _.once(cb);
     if (!(file.contents instanceof Buffer)) {
       return cb(new PluginError(PLUGIN_NAME, 'streams not supported'));
-    }
-
-    if (opts.resolveAbsolutePaths) {
-      file.path = path.resolve(file.path);
     }
 
     instrumenter.instrument(file.contents.toString(), file.path, function (err, code) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var through = require('through2').obj;
 var path = require('path');
 var checker = require('istanbul-threshold-checker');
-// Make sure istanbul is `require`d after the istanbul-threshold-checker to use the istanbul version 
+// Make sure istanbul is `require`d after the istanbul-threshold-checker to use the istanbul version
 // defined in this package.json instead of the one defined in istanbul-threshold-checker.
 var istanbul = require('istanbul');
 var gutil = require('gulp-util');
@@ -22,6 +22,7 @@ var plugin = module.exports = function (opts) {
     instrumenter: istanbul.Instrumenter
   });
   opts.includeUntested = opts.includeUntested === true;
+  opts.resolveAbsolutePaths = opts.resolveAbsolutePaths === true;
 
   var instrumenter = new opts.instrumenter(opts);
 
@@ -29,6 +30,10 @@ var plugin = module.exports = function (opts) {
     cb = _.once(cb);
     if (!(file.contents instanceof Buffer)) {
       return cb(new PluginError(PLUGIN_NAME, 'streams not supported'));
+    }
+
+    if (opts.resolveAbsolutePaths) {
+      file.path = path.resolve(file.path);
     }
 
     instrumenter.instrument(file.contents.toString(), file.path, function (err, code) {
@@ -52,7 +57,7 @@ var plugin = module.exports = function (opts) {
         if (covStubMatch !== null) {
           var covStub = JSON.parse(covStubMatch[0]);
           global[opts.coverageVariable] = global[opts.coverageVariable] || {};
-          global[opts.coverageVariable][path.resolve(file.path)] = covStub;
+          global[opts.coverageVariable][file.path] = covStub;
         }
       }
 


### PR DESCRIPTION
Considering aggregating coverage reports on the same code, but from different installations or locations, linux installation and windows installation for example. In such cases, if the source files would appear under different paths their coverage won't be aggregated into a single asset, but rather would appear per each unique path. 

Provide an option to skip path resolution and work with the provided paths (relative in the mentioned case) thus enabling aggregation.

See #90 
