### PR TITLE
gulp-sourcemap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ gulp.task('test', ['pre-test'], function () {
 });
 ```
 
+#### Source Maps
+gulp-istanbul supports [gulp-sourcemaps][gulp-sourcemaps] when instrumenting:
+
+
+```javascript
+gulp.task('pre-test', function () {
+  return gulp.src(['lib/**/*.js'])
+    // optionally load existing source maps
+    .pipe(sourcemaps.init())
+    // Covering files
+    .pipe(istanbul())
+    .pipe(sourcemaps.write('.'))
+    // Write the covered files to a temporary directory
+    .pipe(gulp.dest('test-tmp/'));
+});
+```
+
 API
 --------------
 
@@ -305,6 +322,7 @@ License
 
 [istanbul]: http://gotwarlost.github.io/istanbul/
 [gulp]: https://github.com/gulpjs/gulp
+[gulp-sourcemaps]: https://github.com/floridoo/gulp-sourcemaps
 
 [npm-url]: https://npmjs.org/package/gulp-istanbul
 [npm-image]: https://badge.fury.io/js/gulp-istanbul.svg

--- a/index.js
+++ b/index.js
@@ -28,11 +28,14 @@ var plugin = module.exports = function (opts) {
 
   return through(function (file, enc, cb) {
     var instrumenter;
+    var fileContents = file.contents.toString();
     if (file.sourceMap) {
       var fileOpts = _.defaultsDeep(_.cloneDeep(opts), {
         codeGenerationOptions: {
-          sourceMap: path.basename(file.path),
+          sourceMap: file.sourceMap.file,
           sourceMapWithCode: true,
+          sourceContent: fileContents,
+          sourceMapRoot: file.sourceMap.sourceRoot,
           file: file.path
         }
       });
@@ -46,7 +49,7 @@ var plugin = module.exports = function (opts) {
       return cb(new PluginError(PLUGIN_NAME, 'streams not supported'));
     }
 
-    instrumenter.instrument(file.contents.toString(), file.path, function (err, code) {
+    instrumenter.instrument(fileContents, file.path, function (err, code) {
       if (err) {
         return cb(new PluginError(
           PLUGIN_NAME,

--- a/index.js
+++ b/index.js
@@ -24,13 +24,12 @@ var plugin = module.exports = function (opts) {
   });
   opts.includeUntested = opts.includeUntested === true;
 
-  var defaultInstrumenter = new opts.instrumenter(opts);
-
   return through(function (file, enc, cb) {
-    var instrumenter;
     var fileContents = file.contents.toString();
+    var fileOpts = _.cloneDeep(opts);
+
     if (file.sourceMap) {
-      var fileOpts = _.defaultsDeep(_.cloneDeep(opts), {
+      fileOpts = _.defaultsDeep(fileOpts, {
         codeGenerationOptions: {
           sourceMap: file.sourceMap.file,
           sourceMapWithCode: true,
@@ -39,10 +38,8 @@ var plugin = module.exports = function (opts) {
           file: file.path
         }
       });
-      instrumenter = new opts.instrumenter(fileOpts);
-    } else {
-      instrumenter = defaultInstrumenter;
     }
+    var instrumenter = new opts.instrumenter(fileOpts);
 
     cb = _.once(cb);
     if (!(file.contents instanceof Buffer)) {

--- a/package.json
+++ b/package.json
@@ -32,11 +32,13 @@
     "istanbul": "^0.4.0",
     "istanbul-threshold-checker": "^0.1.0",
     "lodash": "^4.0.0",
-    "through2": "^2.0.0"
+    "through2": "^2.0.0",
+    "vinyl-sourcemaps-apply": "^0.2.1"
   },
   "devDependencies": {
     "gulp": "^3.6.2",
     "gulp-mocha": "^2.0.0",
+    "gulp-sourcemaps": "^1.6.0",
     "isparta": "^3.0.0",
     "jshint": "^2.5.0",
     "mocha": "^2.0.1",

--- a/test/main.js
+++ b/test/main.js
@@ -91,6 +91,28 @@ describe('gulp-istanbul', function () {
       initStream.end();
     });
 
+    it('handles existing source maps', function(done) {
+        var initStream = sourcemaps.init();
+        var sourceMapStream = initStream.pipe(this.stream);
+        sourceMapStream.on('data', function (file) {
+          assert.equal(file.sourceMap.sourceRoot, 'testSourceRoot');
+          assert(file.sourceMap.sources.indexOf('testInputFile.js') >= 0);
+          done();
+        });
+
+        libFile.sourceMap = {
+          version: 3,
+          sources: [ 'add.js' ],
+          names: [ 'exports', 'add', 'a', 'b', 'missed' ],
+          mappings: ';;;;;;;;;AAEAA,OAAA,CAAQC,GAAR,GAAc,UAAUC,CAAV,EAAaC,CAAb,EAAgB;AAAA,I,sCAAA;AAAA,I,sCAAA;AAAA,IAC5B,OAAOD,CAAA,GAAIC,CAAX,CAD4B;AAAA,CAA9B,C;;AAIAH,OAAA,CAAQI,MAAR,GAAiB,YAAY;AAAA,I,sCAAA;AAAA,I,sCAAA;AAAA,IAC3B,OAAO,aAAP,CAD2B;AAAA,CAA7B',
+          file: 'testInputFile.js',
+          sourcesContent: [ '' ],
+          sourceRoot: 'testSourceRoot'
+        };
+        initStream.write(libFile);
+        initStream.end();
+    });
+
     it('creates sourcemaps only if requested', function(done) {
       this.stream.on('data', function (file) {
         assert(file.sourceMap === undefined);


### PR DESCRIPTION
Escodegen [can generate sourcemaps](https://github.com/estools/escodegen/wiki/API). This is extremely helpful, because it allows to debug instrumented code in the browser.

This PR uses escodegen’s sourcemap feature if the user uses `gulp-sourcemap` and emits the map accodingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sboudrias/gulp-istanbul/94)
<!-- Reviewable:end -->
