### PR TITLE
Fix override default reporters

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,11 +124,11 @@ plugin.writeReports = function (opts) {
   opts = _.defaultsDeep(opts, {
     coverageVariable: COVERAGE_VARIABLE,
     dir: defaultDir,
-    reporters: [ 'lcov', 'json', 'text', 'text-summary' ],
     reportOpts: {
       dir: opts.dir || defaultDir
     }
   });
+  opts.reporters = opts.reporters || [ 'lcov', 'json', 'text', 'text-summary' ];
 
   var reporters = opts.reporters.map(function(reporter) {
     if (reporter.TYPE) Report.register(reporter);

--- a/test/main.js
+++ b/test/main.js
@@ -291,6 +291,7 @@ describe('gulp-istanbul', function () {
           process.stdout.write = out;
           assert(fs.existsSync('./cov-foo'));
           assert(!fs.existsSync('./cov-foo/lcov.info'));
+          assert(!fs.existsSync('./cov-foo/coverage-final.json'));
           assert(fs.existsSync('./cov-foo/cobertura-coverage.xml'));
           process.stdout.write = out;
           done();


### PR DESCRIPTION
Hi!

Trying to limit the istanbul reporters to JSON  with

```js
.pipe(istanbul.writeReports({ reporters: ['json'] }));
```

I observed that other reporters were called too.


The problem is `_.defaultsDeep` doesn't work as expected in this situation.

```js
var opts = {reporters: ['json']}


var opts = _.defaultsDeep(opts,
{reporters: [ 'lcov', 'json', 'text', 'text-summary' ]}
)

console.log(opts)
```
returns
```js
{
  reporters: ["json", "json", "text", "text-summary"]
}
```

As a quick fix, I'm using

```js
.pipe(istanbul.writeReports({ reporters: ['json', 'json', 'json', 'json'] }));
````

;-)

Moving `reporters` out of `_.defaultsDeep` does the trick.
