### PR TITLE
replaced deprecated gulp-util and fixed broken test

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,11 @@ var checker = require('istanbul-threshold-checker');
 // Make sure istanbul is `require`d after the istanbul-threshold-checker to use the istanbul version
 // defined in this package.json instead of the one defined in istanbul-threshold-checker.
 var istanbul = require('istanbul');
-var gutil = require('gulp-util');
 var _ = require('lodash');
 var applySourceMap = require('vinyl-sourcemaps-apply');
 var Report = istanbul.Report;
 var Collector = istanbul.Collector;
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 
 var PLUGIN_NAME = 'gulp-istanbul';
 var COVERAGE_VARIABLE = '$$cov_' + new Date().getTime() + '$$';

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "test": "mocha -R spec"
   },
   "dependencies": {
-    "gulp-util": "^3.0.1",
     "istanbul": "^0.4.0",
     "istanbul-threshold-checker": "^0.2.1",
     "lodash": "^4.0.0",
+    "plugin-error": "^0.1.2",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.1"
   },
@@ -42,7 +42,8 @@
     "isparta": "^4.0.0",
     "jshint": "^2.5.0",
     "mocha": "^4.0.0",
-    "rimraf": "^2.2.8"
+    "rimraf": "^2.2.8",
+    "vinyl": "^2.1.0"
   },
   "license": "MIT"
 }

--- a/test/main.js
+++ b/test/main.js
@@ -3,7 +3,7 @@
 var fs = require('fs');
 var assert = require('assert');
 var rimraf = require('rimraf');
-var gutil = require('gulp-util');
+var File = require('vinyl');
 var gulp = require('gulp');
 var istanbul = require('../');
 var isparta = require('isparta');
@@ -26,7 +26,7 @@ describe('gulp-istanbul', function () {
   describe('istanbul()', function () {
     beforeEach(function () {
       this.stream = istanbul();
-      libFile = new gutil.File({
+      libFile = new File({
         path: 'test/fixtures/lib/add.js',
         cwd: 'test/',
         base: 'test/fixtures/lib',
@@ -48,7 +48,7 @@ describe('gulp-istanbul', function () {
     });
 
     it('throw when receiving a stream', function (done) {
-      var srcFile = new gutil.File({
+      var srcFile = new File({
         path: path.join('test', 'fixtures', 'lib', 'add.js'),
         cwd: 'test/',
         base: 'test/fixtures/lib',
@@ -65,7 +65,7 @@ describe('gulp-istanbul', function () {
     });
 
     it('handles invalid JS files', function (done) {
-      var srcFile = new gutil.File({
+      var srcFile = new File({
         path: path.join('test', 'fixtures', 'lib', 'add.js'),
         cwd: 'test/',
         base: 'test/fixtures/lib',
@@ -84,7 +84,7 @@ describe('gulp-istanbul', function () {
       var sourceMapStream = initStream.pipe(this.stream);
       sourceMapStream.on('data', function (file) {
         assert(file.sourceMap !== undefined);
-        assert.equal(file.sourceMap.file, file.path);
+        assert.equal(file.sourceMap.file, file.path.replace(/\\/g, '/'));
         done();
       });
 


### PR DESCRIPTION
This pr replaces the recently deprecated gulp-util package with corresponding dependencies.

For more info see:

https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
gulpjs/gulp-util#143

Thanks!