### PR TITLE
Updating README with minor example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ You can pass individual configuration to a reporter.
   dir: './coverage',
   reporters: [ 'lcovonly', 'json', 'text', 'text-summary', CustomReport ],
   reportOpts: {
-    lcov: {dir: 'lcovonly', file: 'lcov.info'}
+    lcov: {dir: 'lcovonly', file: 'lcov.info'},
     json: {dir: 'json', file: 'converage.json'}
   },
   coverageVariable: 'someVariable'


### PR DESCRIPTION
The configuration example is missing a comma. Fixes this for use in copy/paste.